### PR TITLE
Windows safe versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - 2.7
   - 3.4
-  - pypy
 # command to install dependencies
 install:
   pip install cython &&

--- a/murmurhash/headers/murmurhash/MurmurHash2.h
+++ b/murmurhash/headers/murmurhash/MurmurHash2.h
@@ -5,24 +5,7 @@
 #ifndef _MURMURHASH2_H_
 #define _MURMURHASH2_H_
 
-//-----------------------------------------------------------------------------
-// Platform-specific functions and macros
-
-// Microsoft Visual Studio
-
-#if defined(_MSC_VER)
-
-typedef unsigned char uint8_t;
-typedef unsigned long uint32_t;
-typedef unsigned __int64 uint64_t;
-
-// Other compilers
-
-#else	// defined(_MSC_VER)
-
 #include <stdint.h>
-
-#endif // !defined(_MSC_VER)
 
 //-----------------------------------------------------------------------------
 

--- a/murmurhash/headers/murmurhash/MurmurHash2.h
+++ b/murmurhash/headers/murmurhash/MurmurHash2.h
@@ -5,7 +5,24 @@
 #ifndef _MURMURHASH2_H_
 #define _MURMURHASH2_H_
 
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+typedef unsigned char uint8_t;
+typedef unsigned long uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
 #include <stdint.h>
+
+#endif // !defined(_MSC_VER)
 
 //-----------------------------------------------------------------------------
 

--- a/murmurhash/headers/murmurhash/MurmurHash3.h
+++ b/murmurhash/headers/murmurhash/MurmurHash3.h
@@ -5,24 +5,7 @@
 #ifndef _MURMURHASH3_H_
 #define _MURMURHASH3_H_
 
-//-----------------------------------------------------------------------------
-// Platform-specific functions and macros
-
-// Microsoft Visual Studio
-
-#if defined(_MSC_VER)
-
-typedef unsigned char uint8_t;
-typedef unsigned long uint32_t;
-typedef unsigned __int64 uint64_t;
-
-// Other compilers
-
-#else	// defined(_MSC_VER)
-
 #include <stdint.h>
-
-#endif // !defined(_MSC_VER)
 
 //-----------------------------------------------------------------------------
 #ifdef __cplusplus

--- a/murmurhash/headers/murmurhash/MurmurHash3.h
+++ b/murmurhash/headers/murmurhash/MurmurHash3.h
@@ -5,7 +5,24 @@
 #ifndef _MURMURHASH3_H_
 #define _MURMURHASH3_H_
 
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+typedef unsigned char uint8_t;
+typedef unsigned long uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
 #include <stdint.h>
+
+#endif // !defined(_MSC_VER)
 
 //-----------------------------------------------------------------------------
 #ifdef __cplusplus

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,10 @@ def install_headers():
         shutil.copytree('murmurhash/headers/murmurhash', dest_dir)
 
 def rm_cflag(text):
-    cflags = distutils.sysconfig._config_vars['CFLAGS']
-    cflags = cflags.replace(text, '')
-    distutils.sysconfig._config_vars['CFLAGS'] = cflags
+    cflags = distutils.sysconfig.get_config_var('CFLAGS')
+    if cflags is not None:
+        cflags = cflags.replace(text, '')
+        distutils.sysconfig._config_vars['CFLAGS'] = cflags
 
 install_headers()
 includes = ['.', path.join(sys.prefix, 'include')]

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,9 @@ def install_headers():
         shutil.copytree('murmurhash/headers/murmurhash', dest_dir)
 
 def rm_cflag(text):
-    cflags = distutils.sysconfig.get_config_var('CFLAGS')
-    if cflags is not None:
-        cflags = cflags.replace(text, '')
-        distutils.sysconfig._config_vars['CFLAGS'] = cflags
+    cflags = distutils.sysconfig._config_vars['CFLAGS']
+    cflags = cflags.replace(text, '')
+    distutils.sysconfig._config_vars['CFLAGS'] = cflags
 
 install_headers()
 includes = ['.', path.join(sys.prefix, 'include')]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ import shutil
 
 distutils.sysconfig.get_config_vars()
 
-
 def install_headers():
     dest_dir = path.join(sys.prefix, 'include', 'murmurhash')
     if not path.exists(dest_dir):

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,10 @@ def install_headers():
         shutil.copytree('murmurhash/headers/murmurhash', dest_dir)
 
 def rm_cflag(text):
-    cflags = distutils.sysconfig._config_vars['CFLAGS']
-    cflags = cflags.replace(text, '')
-    distutils.sysconfig._config_vars['CFLAGS'] = cflags
+    cflags = distutils.sysconfig.get_config_var('CFLAGS')
+    if cflags is not None:
+        cflags = cflags.replace(text, '')
+        distutils.sysconfig._config_vars['CFLAGS'] = cflags
 
 install_headers()
 includes = ['.', path.join(sys.prefix, 'include')]


### PR DESCRIPTION
These changes repeat changes previously applied to headers_workaround and preshed:

1) Removed version specific typedefs in MurmurHash headers
2) Windows safe compiler flag management in setup.py

PyPy build does not work but I believe it did not work in original version either.  